### PR TITLE
Remove the suds-jurko dependncy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author = 'John Obelenus',
     author_email = 'jobelenus@activefrequency.com',
     version=version,
-    install_requires = ['requests==2.5.3', 'decorator==3.4.0', 'suds-jurko==0.6', 'six==1.9.0'],
+    install_requires = ['requests==2.5.3', 'decorator==3.4.0', 'six==1.9.0'],
     package_data = {
         '': ['*.txt', '*.rst', '*.md']
     },


### PR DESCRIPTION
Per be277496dc, soap support was removed in favor of rest/json; thus the
dep is no longer necessary.